### PR TITLE
Use with Java 8

### DIFF
--- a/01-Login/Dockerfile
+++ b/01-Login/Dockerfile
@@ -1,4 +1,4 @@
-FROM gradle:4.2-jdk7
+FROM gradle:4.2-jdk8
 
 WORKDIR /tmp
 ADD . /tmp


### PR DESCRIPTION
Move to requiring Java 8 instead of Java 7. Also required with recent changes to `mvc-auth-commons`  required changes needing Java 8.

Should also fix CI failure for app not starting due to version mismatch.