### PR TITLE
Update to use new APIs

### DIFF
--- a/01-Login/build.gradle
+++ b/01-Login/build.gradle
@@ -24,9 +24,9 @@ repositories {
 
 dependencies {
     compile 'com.auth0:mvc-auth-commons:1.+'
-    compile 'org.springframework.boot:spring-boot-starter-web:1.5.6.RELEASE'
+    compile 'org.springframework.boot:spring-boot-starter-web:1.5.+'
 
-    runtime 'org.springframework.boot:spring-boot-starter-tomcat:1.5.6.RELEASE'
+    runtime 'org.springframework.boot:spring-boot-starter-tomcat:1.5.+'
     runtime 'org.apache.tomcat.embed:tomcat-embed-jasper:8.5.20'
     runtime 'javax.servlet:jstl:1.2'
 

--- a/01-Login/src/main/java/com/auth0/example/AuthController.java
+++ b/01-Login/src/main/java/com/auth0/example/AuthController.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 @Component
 public class AuthController {
@@ -24,13 +25,13 @@ public class AuthController {
                 .build();
     }
 
-    Tokens handle(HttpServletRequest request) throws IdentityVerificationException {
-        return controller.handle(request);
+    Tokens handle(HttpServletRequest request, HttpServletResponse response) throws IdentityVerificationException {
+        return controller.handle(request, response);
     }
 
-    String buildAuthorizeUrl(HttpServletRequest request, String redirectUri) {
+    String buildAuthorizeUrl(HttpServletRequest request, HttpServletResponse response, String redirectUri) {
         return controller
-                .buildAuthorizeUrl(request, redirectUri)
+                .buildAuthorizeUrl(request, response, redirectUri)
                 .build();
     }
 

--- a/01-Login/src/main/java/com/auth0/example/CallbackController.java
+++ b/01-Login/src/main/java/com/auth0/example/CallbackController.java
@@ -29,24 +29,24 @@ public class CallbackController {
     }
 
     @RequestMapping(value = "/callback", method = RequestMethod.GET)
-    protected void getCallback(final HttpServletRequest req, final HttpServletResponse res) throws ServletException, IOException {
-        handle(req, res);
+    protected void getCallback(final HttpServletRequest request, final HttpServletResponse response) throws ServletException, IOException {
+        handle(request, response);
     }
 
     @RequestMapping(value = "/callback", method = RequestMethod.POST, consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
-    protected void postCallback(final HttpServletRequest req, final HttpServletResponse res) throws ServletException, IOException {
-        handle(req, res);
+    protected void postCallback(final HttpServletRequest request, final HttpServletResponse response) throws ServletException, IOException {
+        handle(request, response);
     }
 
-    private void handle(HttpServletRequest req, HttpServletResponse res) throws IOException {
+    private void handle(HttpServletRequest request, HttpServletResponse response) throws IOException {
         try {
-            Tokens tokens = controller.handle(req);
-            SessionUtils.set(req, "accessToken", tokens.getAccessToken());
-            SessionUtils.set(req, "idToken", tokens.getIdToken());
-            res.sendRedirect(redirectOnSuccess);
+            Tokens tokens = controller.handle(request, response);
+            SessionUtils.set(request, "accessToken", tokens.getAccessToken());
+            SessionUtils.set(request, "idToken", tokens.getIdToken());
+            response.sendRedirect(redirectOnSuccess);
         } catch (IdentityVerificationException e) {
             e.printStackTrace();
-            res.sendRedirect(redirectOnFail);
+            response.sendRedirect(redirectOnFail);
         }
     }
 

--- a/01-Login/src/main/java/com/auth0/example/LoginController.java
+++ b/01-Login/src/main/java/com/auth0/example/LoginController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 @SuppressWarnings("unused")
 @Controller
@@ -18,10 +19,10 @@ public class LoginController {
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
     @RequestMapping(value = "/login", method = RequestMethod.GET)
-    protected String login(final HttpServletRequest req) {
+    protected String login(HttpServletRequest request, HttpServletResponse response) {
         logger.debug("Performing login");
-        String redirectUri = req.getScheme() + "://" + req.getServerName() + ":" + req.getServerPort() + "/callback";
-        String authorizeUrl = controller.buildAuthorizeUrl(req, redirectUri);
+        String redirectUri = request.getScheme() + "://" + request.getServerName() + ":" + request.getServerPort() + "/callback";
+        String authorizeUrl = controller.buildAuthorizeUrl(request, response, redirectUri);
         return "redirect:" + authorizeUrl;
     }
 


### PR DESCRIPTION
Updates sample to use the new APIs available in auth0-mvc-commons version 1.2.0:

* `AuthenticationController.buildAuthorizeUrl(request, response, redirectUri)`
* `AuthenticationController.handle(request, response)`

Additional PR will follow in the docs repo to update the Quickstart article.